### PR TITLE
Update aria2.conf

### DIFF
--- a/archiver/aria2.conf
+++ b/archiver/aria2.conf
@@ -102,6 +102,7 @@ enable-peer-exchange=false
 # 客户端伪装, PT需要
 peer-id-prefix=-TR2770-
 user-agent=Transmission/2.77
+peer-agent=Transmission/2.77
 # 当种子的分享率达到这个数时, 自动停止做种, 0为一直做种, 默认:1.0
 seed-ratio=0
 # 强制保存会话, 即使任务已经完成, 默认:false


### PR DESCRIPTION
刚 Google 到 http://aria2c.com/usage.html ，看到 user-agent 配置在 BT 配置节点下，我觉得可能是笔误，BT 的 agent 配置应该是 `peer-agent` ，准备反馈下这个问题，这个仓库应该是 aria2c.com 的吧。

再查了下伪装 BT 客户端这两个参数都要设置，参考了 https://github.com/wu67/my_aria2_conf#readme 那就两个都加上吧。
