### PR TITLE
重新下载任务时移除原有的任务

### DIFF
--- a/js/aria2.js
+++ b/js/aria2.js
@@ -352,6 +352,8 @@ if (typeof ARIA2 == "undefined" || !ARIA2) var ARIA2 = (function() {
 					ARIA2.request("getOption", [gid], function(result) {
 						var options = result.result;
 						ARIA2.madd_task(uris, options);
+						//delete old info(mostly failure).
+						ARIA2.remove_result(gid);
 					});
 				}
 			});


### PR DESCRIPTION
解决重新下载任务时原有任务不消失，导致后期无法管理的问题。
